### PR TITLE
Replace "Github with GitHub" in description

### DIFF
--- a/src/vue/Description.vue
+++ b/src/vue/Description.vue
@@ -35,7 +35,7 @@
             &nbsp;-&nbsp;You can also download the latest build of Vanity-ETH
             <a href="https://git.io/veth-dl" target="_blank">here</a> and use it on a completely offline computer<br>
             &nbsp;-&nbsp;The code is 100% open source and available on
-            <a href="https://github.com/bokub/vanity-eth" target="_blank">Github</a>. You can review it as much as you want before using it<br>
+            <a href="https://github.com/bokub/vanity-eth" target="_blank">GitHub</a>. You can review it as much as you want before using it<br>
             <br>
             Vanity-ETH uses a cryptographically secure pseudorandom number generator (CSPRNG) to generate
             Ethereum addresses.<br>


### PR DESCRIPTION
Fix typo